### PR TITLE
Add issue and feature/suggestion templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an idea or request a feature.
+title: "[REQUEST]"
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] or I see [...] when I know it could be better with [...]
+
+**Describe the solution or feature you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives, workarounds, or minor adjustments you've considered**
+A clear and concise description of any alternative solutions or features you've considered. Answering this does not imply it has any less of a chance of being implemented. 
+
+**Additional context**
+Add any other context or screenshots about the feature request here. Examples from other games, proof of concept screenshots, drawings, etc.—as long as we're able to get a clear picture of what you're thinking of. Message us on the Discord Server as well.


### PR DESCRIPTION
Add an issue/suggestion/feature request template. A simple catch all to allow for easier visualization and documentation of suggestions or bugs made by individuals. Default template modified a little; need more input from team.