### PR TITLE
Removed some warnings from the damage code and changed formatting a bit.

### DIFF
--- a/src/FieldWarning/Assets/Units/Component/Damage/Damage.cs
+++ b/src/FieldWarning/Assets/Units/Component/Damage/Damage.cs
@@ -11,18 +11,17 @@
  * the License for the specific language governing permissions and limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Diagnostics;
-
 namespace PFW.Units.Component.Damage
 {
     /// <summary>
     /// The base class Damage, on which all damage classes are constructed
-    /// This class represents a damage dealt in an update, for one-time instant damage (e.g. KEDamage or HeatDamage), the class will be instantiated once
-    /// For continuous damage (e.g. FireDamage), the class will be instantiated once and the CalculateDamage will be called at every update (controlled by another script inherenting MonoBehaviour)
+    ///
+    /// This class represents a damage dealt in an update, for one-time instant damage
+    /// (e.g. KEDamage or HeatDamage), the class will be instantiated once
+    ///
+    /// For continuous damage (e.g. FireDamage), the class will be instantiated once and
+    /// the CalculateDamage will be called at every update (controlled by another
+    /// script inherenting MonoBehaviour)
     /// </summary>
     internal abstract class Damage
     {

--- a/src/FieldWarning/Assets/Units/Component/Damage/FireDamage.cs
+++ b/src/FieldWarning/Assets/Units/Component/Damage/FireDamage.cs
@@ -12,10 +12,6 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Diagnostics;
 
 namespace PFW.Units.Component.Damage
 {

--- a/src/FieldWarning/Assets/Units/Component/Damage/HeatDamage.cs
+++ b/src/FieldWarning/Assets/Units/Component/Damage/HeatDamage.cs
@@ -12,10 +12,6 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Diagnostics;
 
 namespace PFW.Units.Component.Damage
 {
@@ -43,7 +39,7 @@ namespace PFW.Units.Component.Damage
                     finalState.EraData.Value - heat.Power * finalState.EraData.HeatFractionMultiplier
                 );
                 finalState.EraData.Value = finalEra;
-                
+
                 heat.Power = CalculatePostEraPower(
                     heat.Power,
                     finalState.EraData.HeatFractionMultiplier
@@ -67,7 +63,7 @@ namespace PFW.Units.Component.Damage
                 finalState.Health - finalDamage
             );
             finalState.Health = finalHealth;
-            
+
             return finalState;
         }
 

--- a/src/FieldWarning/Assets/Units/Component/Damage/KEDamage.cs
+++ b/src/FieldWarning/Assets/Units/Component/Damage/KEDamage.cs
@@ -12,10 +12,6 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Diagnostics;
 
 namespace PFW.Units.Component.Damage
 {
@@ -74,7 +70,7 @@ namespace PFW.Units.Component.Damage
                 finalState.Health - finalDamage
             );
             finalState.Health = finalHealth;
-            
+
             return finalState;
         }
 
@@ -83,7 +79,7 @@ namespace PFW.Units.Component.Damage
         {
             return  (float)Math.Exp(-friction * distance) * power;
         }
-        
+
         private static float CalculatePostEraPower(float power, float eraFractionMultiplier)
         {
             return power * (1 - eraFractionMultiplier);

--- a/src/FieldWarning/Assets/Units/UnitDispatcher.cs
+++ b/src/FieldWarning/Assets/Units/UnitDispatcher.cs
@@ -147,7 +147,7 @@ namespace PFW.Units
 
         public float GetHealth() => _healthComponent.Health;
         public float MaxHealth => _movementComponent.Data.maxHealth;
-        
+
         // TODO: move HandelHit to ArmorComponent
 
         /// <summary>
@@ -161,7 +161,8 @@ namespace PFW.Units
 
             // TODO: implement armor and ERA systems
             unitAsTarget.Armor = 0.0f;
-            unitAsTarget.EraData = new Damage.Era();
+            unitAsTarget.EraData = new Damage.Era {
+                    Value = 0, KEFractionMultiplier = 0, HeatFractionMultiplier = 0};
 
             unitAsTarget.Health = _healthComponent.Health;
 
@@ -172,28 +173,35 @@ namespace PFW.Units
             {
                 case DamageTypes.KE:
                     KEDamage keDamage = new KEDamage (
-                        receivedDamage.KineticData.GetValueOrDefault(),
-                        unitAsTarget, distanceToTarget.GetValueOrDefault()
+                            receivedDamage.KineticData.GetValueOrDefault(),
+                            unitAsTarget,
+                            distanceToTarget.GetValueOrDefault()
                     );
                     finalState = keDamage.CalculateDamage();
                     break;
                 case DamageTypes.HEAT:
-                    HeatDamage heatDamage = new HeatDamage(receivedDamage.HeatData.GetValueOrDefault(), unitAsTarget);
+                    HeatDamage heatDamage = new HeatDamage(
+                            receivedDamage.HeatData.GetValueOrDefault(),
+                            unitAsTarget);
                     finalState = heatDamage.CalculateDamage();
                     break;
                 case DamageTypes.HE:
                     HEDamage heDamage = new HEDamage (
-                        receivedDamage.HEData.GetValueOrDefault(),
-                        unitAsTarget, distanceToCentre.GetValueOrDefault()
+                            receivedDamage.HEData.GetValueOrDefault(),
+                            unitAsTarget, distanceToCentre.GetValueOrDefault()
                     );
                     finalState = heDamage.CalculateDamage();
                     break;
                 case DamageTypes.FIRE:
-                    FireDamage fireDamage = new FireDamage(receivedDamage.FireData.GetValueOrDefault(), unitAsTarget);
+                    FireDamage fireDamage = new FireDamage(
+                            receivedDamage.FireData.GetValueOrDefault(),
+                            unitAsTarget);
                     finalState = fireDamage.CalculateDamage();
                     break;
                 case DamageTypes.SMALLARMS:
-                    SmallarmsDamage lightarmsDamage = new SmallarmsDamage(receivedDamage.LightarmsData.GetValueOrDefault(), unitAsTarget);
+                    SmallarmsDamage lightarmsDamage = new SmallarmsDamage(
+                            receivedDamage.LightarmsData.GetValueOrDefault(),
+                            unitAsTarget);
                     break;
                 default:
                     Debug.LogError("Not a valid damage type!");


### PR DESCRIPTION
Double indent when the newline is breaking up a single expression (didnt do everywhere, just in files where that's already the standard).
Broke up some very long lines.

Removed some trailing whitespace and some unused includes.