### PR TITLE
Had a bug with deleting duplicated DontDestroyOnLoad objects. Cleaned…

### DIFF
--- a/src/FieldWarning/Assets/Camera/SlidingCameraBehaviour.cs
+++ b/src/FieldWarning/Assets/Camera/SlidingCameraBehaviour.cs
@@ -129,32 +129,36 @@ public class SlidingCameraBehaviour : MonoBehaviour
 
     private void Awake()
     {
+        // NOTE: becareful when accessing terrain data here as there is a duplicate from when the scene loads.
+        // This duplicate terrain eventually deletes itself when it realizes its a duplicate.. but it maybe too late from
+        // this AWAKE. Therefore; I moved the accessing of Terrain to Start.
+    }
+
+    private void Start()
+    {
         List<MicroSplatTerrain> splatList = new List<MicroSplatTerrain>();
 
-        foreach (Terrain terrain in GameObject.FindObjectsOfType<Terrain>()) 
+        foreach (Terrain terrain in GameObject.FindObjectsOfType<Terrain>())
         {
             splatList.AddRange(terrain.GetComponents<MicroSplatTerrain>());
         }
 
-        if (splatList.Count > 0) 
+        if (splatList.Count > 0)
         {
             _microSplatTerrains = splatList.ToArray();
-        } 
-        else 
+        }
+        else
         {
             throw new Exception("Camera not set up correctly, microsplat reference missing!");
         }
 
-        if (_terrainMaterials == null || _terrainMaterials.Count == 0) 
+        if (_terrainMaterials == null || _terrainMaterials.Count == 0)
         {
             throw new Exception("Camera not set up correctly, terrain materials missing!");
         }
 
         _cam = GetComponent<Camera>();
-    }
 
-    private void Start()
-    {
         _rotateX = transform.eulerAngles.x;
         _rotateY = transform.eulerAngles.y;
         _targetPosition = transform.position;

--- a/src/FieldWarning/Assets/Loading/LoadedData.cs
+++ b/src/FieldWarning/Assets/Loading/LoadedData.cs
@@ -31,6 +31,12 @@ namespace PFW.Loading
 
             Terrain[] terrains = GameObject.FindObjectsOfType<Terrain>();
 
+            foreach(Terrain t in terrains)
+            {
+                MicroSplatTerrain msTerrain =  Terrain.FindObjectOfType<MicroSplatTerrain>();
+                msTerrain.Sync();
+            }
+
             terrainData = new TerrainMap(terrains, scene);
 
             pathFinderData = new PathfinderData(terrainData);

--- a/src/FieldWarning/Assets/Util/DontDestroyOnLoad.cs
+++ b/src/FieldWarning/Assets/Util/DontDestroyOnLoad.cs
@@ -21,8 +21,7 @@ namespace PFW.Loading
     /// </summary>
     public class DontDestroyOnLoad : MonoBehaviour
     {
-        // used to keep track of duplicates
-        // New objects have a lower id
+        // used to keep track of what to keep
         public int Id = 0;
 
         // For duplicates, we erase ourselves if we are the old duplicate and
@@ -34,35 +33,43 @@ namespace PFW.Loading
         {
             DontDestroyOnLoad(this.gameObject);
             SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+
+        private void OnSceneLoaded(Scene aScene, LoadSceneMode aMode)
+        {
+            Id++;
 
             // checks to see if there are other objects that identically named but have different id's...
             // those are duplicates... remove them.
             var components = FindObjectsOfType<DontDestroyOnLoad>();
             foreach (var c in components)
             {
-                
-                // we are checking to make sure there indeed is a duplicate named object
-                if (c.gameObject.name == gameObject.name)
+
+                // we are checking to make sure there indeed is a duplicate named object but not ourselves
+                if (c.gameObject.name != gameObject.name || Id == c.Id)
                 {
-                    // This determines if we should keep the new or old duplicate
-                    if (KeepNewer && Id > c.Id)
-                    {
-                        DestroyImmediate(this.gameObject);
-                        
-                    }
-                    else if (!KeepNewer && Id < c.Id)
-                    {
-                        DestroyImmediate(this.gameObject);
-                    }
-
-                    return;
+                    continue;
                 }
-            }
-        }
 
-        private void OnSceneLoaded(Scene aScene, LoadSceneMode aMode)
-        {
-            Id++;
+                if (!KeepNewer)
+                {
+                    if (Id < c.Id)
+                    {
+                        Debug.Log("Destroying duplicate. Id: " + Id);
+                        DestroyImmediate(this.gameObject);
+                        return;
+                    }
+                } else
+                {
+                    if (Id > c.Id)
+                    {
+                        Debug.Log("Destroying duplicate. Id: " + Id);
+                        DestroyImmediate(this.gameObject);
+                        return;
+                    }
+                }
+                
+            }
         }
     }
 }


### PR DESCRIPTION
… up that code a bit and made it more clear to understand and flexible to use.

Then I noticed SlidingCameraBehaviour was trying to use the wrong DontDestroyOnLoad terrain in Awake. Awake is too early to be using terrain because it may still not have cleaned it self up yet. Moved the SlidingCameraBehaviour initialization Awake code to Start.