### PR TITLE
Wertz public branch

### DIFF
--- a/src/FieldWarning/.vsconfig
+++ b/src/FieldWarning/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [ 
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+} 

--- a/src/FieldWarning/Assets/Units/Component/Movement/MovementComponent.cs
+++ b/src/FieldWarning/Assets/Units/Component/Movement/MovementComponent.cs
@@ -24,6 +24,7 @@ namespace PFW.Units.Component.Movement
         private const float ORIENTATION_RATE = 8.0f;
         private const float TRANSLATION_RATE = 6.0f;
 
+        public Vector3 Velocity; //{ get; private set; }
         public DataComponent Data { get; private set; }
         public Pathfinder Pathfinder { get; private set; }
 
@@ -74,13 +75,22 @@ namespace PFW.Units.Component.Movement
             UpdateCurrentPosition();
         }
 
-        private void UpdateCurrentPosition()
+        private void UpdateCurrentPosition()  
         {
+            //update position and velocity param of this unit
+
+
+
             Vector3 diff = (_moveStrategy.NextPosition - transform.position) * Time.deltaTime;
             Vector3 newPosition = transform.position;
             newPosition.x += TRANSLATION_RATE * diff.x;
             newPosition.y = _moveStrategy.NextPosition.y;
             newPosition.z += TRANSLATION_RATE * diff.z;
+
+            Velocity.x = TRANSLATION_RATE * diff.x;
+            Velocity.y = newPosition.y - transform.position.y;
+            Velocity.z = TRANSLATION_RATE * diff.z;
+            Velocity = Velocity / Time.deltaTime;
 
             transform.position = newPosition;
         }

--- a/src/FieldWarning/Assets/Units/Component/Movement/MovementComponent.cs
+++ b/src/FieldWarning/Assets/Units/Component/Movement/MovementComponent.cs
@@ -79,14 +79,13 @@ namespace PFW.Units.Component.Movement
         {
             //update position and velocity param of this unit
 
-
-
             Vector3 diff = (_moveStrategy.NextPosition - transform.position) * Time.deltaTime;
             Vector3 newPosition = transform.position;
             newPosition.x += TRANSLATION_RATE * diff.x;
             newPosition.y = _moveStrategy.NextPosition.y;
             newPosition.z += TRANSLATION_RATE * diff.z;
 
+            //calculate instantaneous velocity property to be read from outside for shell-lead
             Velocity.x = TRANSLATION_RATE * diff.x;
             Velocity.y = newPosition.y - transform.position.y;
             Velocity.z = TRANSLATION_RATE * diff.z;

--- a/src/FieldWarning/Assets/Units/Component/Weapon/Cannon.cs
+++ b/src/FieldWarning/Assets/Units/Component/Weapon/Cannon.cs
@@ -184,7 +184,11 @@ namespace PFW.Units.Component.Weapon
             }
 
             ShellBehaviour shellBehaviour = shell.GetComponent<ShellBehaviour>();
-            shellBehaviour.Initialize(shellDestination, ammo, target.Enemy.gameObject.GetComponent<PFW.Units.Component.Movement.MovementComponent>().Velocity);
+            shellBehaviour.Initialize(
+                shellDestination, 
+                ammo, 
+                target.Enemy.gameObject.GetComponent<PFW.Units.Component.Movement.MovementComponent>().Velocity
+                );
 
             return true;
         }

--- a/src/FieldWarning/Assets/Units/Component/Weapon/Cannon.cs
+++ b/src/FieldWarning/Assets/Units/Component/Weapon/Cannon.cs
@@ -184,23 +184,7 @@ namespace PFW.Units.Component.Weapon
             }
 
             ShellBehaviour shellBehaviour = shell.GetComponent<ShellBehaviour>();
-            shellBehaviour.Initialize(shellDestination, ammo);
-
-            if (isServer)
-            {
-                if (target.IsUnit)
-                {
-                    if (isHit && !ammo.IsAoe)
-                    {
-                        target.Enemy.HandleHit(
-                                ammo.DamageType, ammo.DamageValue, displacement, distance);
-                    }
-                }
-                else
-                {
-                    // HE damage is applied by the shellBehavior when it explodes
-                }
-            }
+            shellBehaviour.Initialize(shellDestination, ammo, target.Enemy.gameObject.GetComponent<PFW.Units.Component.Movement.MovementComponent>().Velocity);
 
             return true;
         }

--- a/src/FieldWarning/Assets/Units/Prefab/Resources/shell.prefab
+++ b/src/FieldWarning/Assets/Units/Prefab/Resources/shell.prefab
@@ -46,9 +46,9 @@ CapsuleCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   m_Radius: 0.05
-  m_Height: 2
+  m_Height: 1
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 1}
+  m_Center: {x: 0, y: 0, z: 0.8}
 --- !u!136 &9121148859323275930
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -60,9 +60,9 @@ CapsuleCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.05
-  m_Height: 2
+  m_Height: 1
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 1}
+  m_Center: {x: 0, y: 0, z: 0.8}
 --- !u!114 &114877143042695842
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/src/FieldWarning/Assets/Units/Prefab/Resources/shell.prefab
+++ b/src/FieldWarning/Assets/Units/Prefab/Resources/shell.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4947632754763960}
   - component: {fileID: 136052954316136422}
+  - component: {fileID: 9121148859323275930}
   - component: {fileID: 114877143042695842}
   - component: {fileID: 54854243726031328}
   m_Layer: 0
@@ -42,12 +43,26 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1549430693258728}
   m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  m_Radius: 0.9437419
+  m_Height: 20
+  m_Direction: 2
+  m_Center: {x: 0, y: -0.045321055, z: 0}
+--- !u!136 &9121148859323275930
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1549430693258728}
+  m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.9437419
-  m_Height: 2
+  m_Height: 5
   m_Direction: 2
-  m_Center: {x: 0, y: -0.045321055, z: 0}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &114877143042695842
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/src/FieldWarning/Assets/Units/Prefab/Resources/shell.prefab
+++ b/src/FieldWarning/Assets/Units/Prefab/Resources/shell.prefab
@@ -45,10 +45,10 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
-  m_Radius: 0.9437419
-  m_Height: 20
+  m_Radius: 0.05
+  m_Height: 2
   m_Direction: 2
-  m_Center: {x: 0, y: -0.045321055, z: 0}
+  m_Center: {x: 0, y: 0, z: 1}
 --- !u!136 &9121148859323275930
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -59,10 +59,10 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  m_Radius: 0.9437419
-  m_Height: 5
+  m_Radius: 0.05
+  m_Height: 2
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 0, z: 1}
 --- !u!114 &114877143042695842
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/src/FieldWarning/Assets/Units/ShellBehaviour.cs
+++ b/src/FieldWarning/Assets/Units/ShellBehaviour.cs
@@ -53,13 +53,12 @@ namespace PFW.Units.Component.Weapon
         ///     Call in the weapon class to initialize the shell/bullet.
         /// </summary>
         /// <param name="velocity">In meters.</param>
-        public void Initialize(Vector3 target, Ammo ammo, Vector3 targetVelocity) ///, Collider launchPlatform)
+        public void Initialize(Vector3 target, Ammo ammo, Vector3 targetVelocity)
         {
             _targetCoordinates = target;
             _ammo = ammo;
             _targetVelocity = targetVelocity;
             _initialDistanceToTarget = (_targetCoordinates - transform.position).magnitude;
-            ///_launchPlatform = launchPlatform;
         }
 
         private void Start()
@@ -128,25 +127,13 @@ namespace PFW.Units.Component.Weapon
             worldForward = new Vector3(worldForward.x, 0, worldForward.z);
             Vector3 translation = _forwardSpeed * worldForward * Time.deltaTime
                                   + _verticalSpeed * Vector3.up * Time.deltaTime
-                                  + _targetVelocity * Time.deltaTime; // * Constants.MAP_SCALE;
-            transform.LookAt(transform.position + translation);
+                                  + _targetVelocity * Time.deltaTime; /// * Constants.MAP_SCALE;
+            ///transform.LookAt(transform.position + translation);
             transform.Translate(
                     translation,
                     Space.World);
 
             _verticalSpeed -= GRAVITY * Time.deltaTime;
-
-
-            // small trick to detect if shell has reached the target
-            //float distanceToTarget = Vector3.Distance(transform.position, _targetCoordinates);
-            //if (distanceToTarget > _prevDistanceToTarget)
-            //{
-            //    transform.position = _targetCoordinates;
-            //    Explode();
-            //}
-            //_prevDistanceToTarget = distanceToTarget;
-
-            //transform.rotation.SetLookRotation(translation);
 
             if (_justLaunched)
             {
@@ -175,8 +162,11 @@ namespace PFW.Units.Component.Weapon
                 {
                     Explode();
                 }
+                else
+                {
+                    ///_verticalSpeed = -_verticalSpeed;
+                }
             }
-            
 
         }
 


### PR DESCRIPTION
Tank shell damage successfully moved from being instantly applied on shooting to being dealt upon the round actually hitting the target, done in the actual ShellBehavior collision logic now and utilizing collision shapes in the 3D world. 
Shell velocity is tweaked based on the target velocity at launch such that it will have the same lateral displacement as the target (lead) over time. To do this, I had to make a manual Velocity property in the MovementComponent to reference.