### PR TITLE
Artillery arc via velocity (and fixed artillery from my last changes to ShellBehavior)

### DIFF
--- a/src/FieldWarning/Assets/StreamingAssets/UnitConfigs/RED/Koalitsiya.json
+++ b/src/FieldWarning/Assets/StreamingAssets/UnitConfigs/RED/Koalitsiya.json
@@ -69,7 +69,7 @@
                     "SalvoReload": 8,
                     "MuzzleFlash": "Effects/ParticleFX/Prefab/Muzzle Flash",
                     "Shell": "Projectiles/Prefab/BLUFOR Shell",
-                    "Velocity": 1000,
+                    "Velocity": 380,
                     "Sound": "WeaponSounds/Tank_gun",
                     "BarrelTipRef": "Cannon",
                     "WeaponIcon": "WeaponIcons/US_AR_M4A1",

--- a/src/FieldWarning/Assets/Units/Component/Weapon/Cannon.cs
+++ b/src/FieldWarning/Assets/Units/Component/Weapon/Cannon.cs
@@ -183,11 +183,22 @@ namespace PFW.Units.Component.Weapon
                 }
             }
 
+
+            Vector3 targetVel;
+            if (target.IsUnit)
+            {
+                targetVel = target.Enemy.gameObject.GetComponent<PFW.Units.Component.Movement.MovementComponent>().Velocity;
+            }
+            else
+            {
+                targetVel = Vector3.zero;
+            }
+
             ShellBehaviour shellBehaviour = shell.GetComponent<ShellBehaviour>();
             shellBehaviour.Initialize(
                 shellDestination, 
-                ammo, 
-                target.Enemy.gameObject.GetComponent<PFW.Units.Component.Movement.MovementComponent>().Velocity
+                ammo,
+                targetVel
                 );
 
             return true;

--- a/src/FieldWarning/Assets/Units/ShellBehaviour.cs
+++ b/src/FieldWarning/Assets/Units/ShellBehaviour.cs
@@ -40,6 +40,8 @@ namespace PFW.Units.Component.Weapon
         private Vector3 _targetVelocity;
         //targetVelocity is the instantaneous target velocity when this shell is fired.
 
+        private Vector3 _worldForward;
+
         private bool _dead = false;
         private float _prevDistanceToTarget = 100000F;
         private float _initialDistanceToTarget;
@@ -74,6 +76,10 @@ namespace PFW.Units.Component.Weapon
             // rotate the object to face the target
             transform.LookAt(_targetCoordinates);
             transform.rotation *= angle;
+
+            _worldForward = (_targetCoordinates - transform.position);
+            _worldForward.y = 0;
+            _worldForward = _worldForward.normalized;
         }
 
         /// <summary>
@@ -122,12 +128,12 @@ namespace PFW.Units.Component.Weapon
                 return;
             }
 
-            Vector3 worldForward = transform.TransformDirection(Vector3.forward);
-            worldForward = new Vector3(worldForward.x, 0, worldForward.z);
-            Vector3 translation = _forwardSpeed * worldForward * Time.deltaTime
+            //Vector3 worldForward = transform.TransformDirection(Vector3.forward);
+            //worldForward = new Vector3(worldForward.x, 0, worldForward.z);
+            Vector3 translation = _forwardSpeed * _worldForward * Time.deltaTime
                                   + _verticalSpeed * Vector3.up * Time.deltaTime
                                   + _targetVelocity * Time.deltaTime; /// * Constants.MAP_SCALE;
-            ///transform.LookAt(transform.position + translation);
+            transform.LookAt(transform.position + translation);
             transform.Translate(
                     translation,
                     Space.World);


### PR DESCRIPTION
Artillery has a significant arc now just from changing the velocity, is still accurate.
Small changes to make sure that the shell model stays aligned with its velocity as it travels, without changing its direction of flight and resulting in a 'curving bullet' effect (sideways).